### PR TITLE
Make UartParams constructible outside of clap

### DIFF
--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -22,15 +22,15 @@ use crate::transport::TransportError;
 pub struct UartParams {
     /// UART instance.
     #[arg(long, default_value = "CONSOLE")]
-    uart: String,
+    pub uart: String,
 
     /// UART baudrate.
     #[arg(long)]
-    baudrate: Option<u32>,
+    pub baudrate: Option<u32>,
 
     /// Enable software flow control.
     #[arg(long)]
-    flow_control: bool,
+    pub flow_control: bool,
 }
 
 impl UartParams {


### PR DESCRIPTION
Unless I've missed something obvious, it's not possible to construct this type outside of clap and it's need in order to invoke bootstrap from opentitanlib.  All of the other *Parms structs inside src/io also have their fields public.